### PR TITLE
docs(toast): add Update example, fix offsets wording, add page idle note, and props tables

### DIFF
--- a/apps/www/content/docs/components/toast.mdx
+++ b/apps/www/content/docs/components/toast.mdx
@@ -89,6 +89,12 @@ of the promise.
 
 <ExampleTabs name="toaster-with-promise" />
 
+### Update
+
+Update an in-progress toast using `toaster.update(id, options)`.
+
+<ExampleTabs name="toaster-with-update" />
+
 ### Custom Duration
 
 Use the `duration` prop to set the duration of the toast.
@@ -147,9 +153,19 @@ const toaster = createToaster({
 })
 ```
 
+### Page Idle Behavior
+
+Pause toast timers when the page is idle/hidden.
+
+```tsx title="@/components/ui/toaster.tsx"
+const toaster = createToaster({
+  pauseOnPageIdle: true,
+})
+```
+
 ### Offset
 
-Set the `offset` prop in the `createToaster` function to offset the toasts from
+Set the `offsets` prop in the `createToaster` function to offset the toasts from
 the edges of the screen.
 
 ```jsx title="@/components/ui/toaster.tsx"
@@ -158,7 +174,7 @@ const toaster = createToaster({
 })
 ```
 
-Alternatively, you can use the `offset` prop to set the offset for each edge of
+Alternatively, you can use the `offsets` prop to set the offset for each edge of
 the screen.
 
 ```jsx title="@/components/ui/toaster.tsx"
@@ -166,3 +182,13 @@ const toaster = createToaster({
   offsets: { left: "20px", top: "20px", right: "20px", bottom: "20px" },
 })
 ```
+
+## Props
+
+<PropTable component="Toaster" part="Toaster" />
+
+<PropTable component="Toast" part="Root" />
+<PropTable component="Toast" part="Title" />
+<PropTable component="Toast" part="Description" />
+<PropTable component="Toast" part="ActionTrigger" />
+<PropTable component="Toast" part="CloseTrigger" />


### PR DESCRIPTION
Summary
- Add "Update" section referencing existing example (toaster-with-update)
- Fix wording: offset -> offsets to match usage
- Add a short "Page Idle Behavior" note showing pauseOnPageIdle in the toaster snippet
- Add Props tables for Toaster and Toast parts

Scope
- Only touches: apps/www/content/docs/components/toast.mdx

Rationale
- Updating existing toasts via id is a common imperative pattern, complementary to toaster.promise
- Clarifies offsets API usage, improves discoverability of pauseOnPageIdle
- Props tables bring Toast docs in line with other components

Testing
- Content renders in MDX; examples refer to existing compositions

Checklist
- [x] Docs build locally (MDX change only)
- [x] No code changes outside docs



---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author